### PR TITLE
Add MQTT TLS/SSL support and update dependencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,8 @@ MQTT_USERNAME = os.getenv('MQTT_USERNAME')
 MQTT_PASSWORD = os.getenv('MQTT_PASSWORD')
 MQTT_KEEPALIVE = int(os.getenv('MQTT_KEEPALIVE', 60))
 MQTT_VERSION = os.getenv('MQTT_VERSION', '3.1.1')
+MQTT_TLS = os.getenv('MQTT_TLS', 'False').lower() in ('true', '1', 't')
+MQTT_TLS_INSECURE = os.getenv('MQTT_TLS_INSECURE', 'False').lower() in ('true', '1', 't')
 # Support for topic filtering (issue #6)
 MQTT_TOPICS = os.getenv('MQTT_TOPICS', '#')  # Comma-separated list of topics to subscribe to
 
@@ -128,7 +130,17 @@ mqtt_username = os.getenv('MQTT_USERNAME')
 mqtt_password = os.getenv('MQTT_PASSWORD')
 mqtt_keepalive = int(os.getenv('MQTT_KEEPALIVE', 60))
 
-logging.info(f"MQTT Setup - Broker: {mqtt_broker}, Port: {mqtt_port}, Username: {'Set' if mqtt_username else 'Not set'}, Password: {'Set' if mqtt_password else 'Not set'}, Version: {mqtt_version}")
+# Apply TLS if requested
+if MQTT_TLS:
+    try:
+        mqtt_client.tls_set()
+        if MQTT_TLS_INSECURE:
+            mqtt_client.tls_insecure_set(True)
+        logging.info(f"MQTT TLS enabled (Insecure: {MQTT_TLS_INSECURE})")
+    except Exception as e:
+        logging.error(f"Failed to set up MQTT TLS: {e}")
+
+logging.info(f"MQTT Setup - Broker: {mqtt_broker}, Port: {mqtt_port}, Username: {'Set' if mqtt_username else 'Not set'}, Password: {'Set' if mqtt_password else 'Not set'}, Version: {mqtt_version}, TLS: {MQTT_TLS}")
 
 messages = []
 topics = set()
@@ -159,7 +171,7 @@ def on_connect(client, userdata, flags, reason_code, properties):
     debug_bar.record('mqtt', 'connection_status', connection_status)
     
     logging.info(f"MQTT Connection attempt - Result: {connection_status}")
-    logging.info(f"MQTT Connection details - Broker: {mqtt_broker}, Port: {mqtt_port}, Username: {'Set' if mqtt_username else 'Not set'}, Password: {'Set' if mqtt_password else 'Not set'}, Protocol: MQTT v{mqtt_version}")
+    logging.info(f"MQTT Connection details - Broker: {mqtt_broker}, Port: {mqtt_port}, Username: {'Set' if mqtt_username else 'Not set'}, Password: {'Set' if mqtt_password else 'Not set'}, Protocol: MQTT v{mqtt_version}, TLS: {MQTT_TLS}")
     
     if rc == 0:
         connection_count += 1
@@ -503,6 +515,8 @@ if __name__ == '__main__' or __name__ == 'app':
         debug_bar.record('mqtt', 'username', mqtt_username if mqtt_username else 'Not set')
         debug_bar.record('mqtt', 'password', 'Set' if mqtt_password else 'Not set')
         debug_bar.record('mqtt', 'protocol', f'MQTT v{mqtt_version}')
+        debug_bar.record('mqtt', 'tls', 'Enabled' if MQTT_TLS else 'Disabled')
+        debug_bar.record('mqtt', 'tls_insecure', str(MQTT_TLS_INSECURE))
         debug_bar.record('mqtt', 'subscribed_topics', MQTT_TOPICS)
         
         logging.info(f"Attempting to connect to MQTT broker at {mqtt_broker}:{mqtt_port}")

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ __version__ = "1.3.0"
 from flask import Flask, render_template, request, jsonify, send_from_directory
 from flask_socketio import SocketIO, emit
 import paho.mqtt.client as mqtt
+from paho.mqtt.enums import CallbackAPIVersion
 from datetime import datetime, timedelta
 import os
 from debug_bar import debug_bar, debug_bar_middleware
@@ -115,10 +116,10 @@ def after_request(response):
 # MQTT setup
 mqtt_version = os.getenv('MQTT_VERSION', '3.1.1')
 if mqtt_version == '5':
-    mqtt_client = mqtt.Client(client_id=f"mqttui_{os.getpid()}", protocol=mqtt.MQTTv5)
+    mqtt_client = mqtt.Client(CallbackAPIVersion.VERSION2, client_id=f"mqttui_{os.getpid()}", protocol=mqtt.MQTTv5)
     logging.info("Using MQTT v5")
 else:
-    mqtt_client = mqtt.Client(client_id=f"mqttui_{os.getpid()}", clean_session=True, protocol=mqtt.MQTTv311)
+    mqtt_client = mqtt.Client(CallbackAPIVersion.VERSION2, client_id=f"mqttui_{os.getpid()}", protocol=mqtt.MQTTv311)
     logging.info("Using MQTT v3.1.1")
 
 mqtt_broker = os.getenv('MQTT_BROKER', 'localhost')
@@ -149,9 +150,10 @@ def handle_disconnect():
     debug_bar.record('performance', 'active_websockets', active_websockets)
     logging.info(f"WebSocket disconnected. Total active: {active_websockets}")
 
-def on_connect(client, userdata, flags, rc, properties=None):
-    # MQTT v5 includes 'properties' parameter, v3.1.1 doesn't (fixes issue #8)
+def on_connect(client, userdata, flags, reason_code, properties):
+    # MQTT v2.0+ uses reason_code instead of rc
     global connection_count
+    rc = reason_code.value if hasattr(reason_code, 'value') else reason_code
     error_message = MQTT_RC_CODES.get(rc, f"Unknown error (rc: {rc})")
     connection_status = 'Connected' if rc == 0 else f'Failed: {error_message}'
     debug_bar.record('mqtt', 'connection_status', connection_status)
@@ -175,9 +177,10 @@ def on_connect(client, userdata, flags, rc, properties=None):
         time.sleep(5)
         connect_mqtt()  # Retry connection
 
-def on_disconnect(client, userdata, rc):
+def on_disconnect(client, userdata, flags, reason_code, properties):
     global connection_count
     connection_count = max(0, connection_count - 1)
+    rc = reason_code.value if hasattr(reason_code, 'value') else reason_code
     error_message = MQTT_RC_CODES.get(rc, f"Unknown error (rc: {rc})")
     disconnect_reason = 'Clean disconnect' if rc == 0 else f'Unexpected disconnect: {error_message}'
     debug_bar.record('mqtt', 'last_disconnect', disconnect_reason)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==2.0.1
-Flask-SocketIO==5.1.1
-paho-mqtt==1.5.1
-Werkzeug==2.0.1
-psutil==5.9.0
-python-dotenv==0.19.0
-gunicorn==20.1.0
-eventlet==0.30.2
+Flask==3.1.2
+Flask-SocketIO==5.6.0
+paho-mqtt==2.1.0
+Werkzeug==3.1.5
+psutil==7.2.1
+python-dotenv==1.2.1
+gunicorn==23.0.0
+eventlet==0.40.4


### PR DESCRIPTION
This PR introduces support for secure MQTT connections and brings the project dependencies up to date.

 **MQTT TLS/SSL Support:**
 - Added MQTT_TLS and MQTT_TLS_INSECURE environment variable support to app.py.
 - Implemented tls_set() to allow encrypted connections to brokers on port 8883 (e.g., Let's Encrypt secured brokers).
 - Added tls_insecure_set() for handling specific verification needs.

**Enhanced Logging & Debugging:**
- Updated the startup sequence and on_connect logs to display TLS status.
- Added TLS information to the Debug Bar for easier connection troubleshooting.

**Dependency Updates:**
 - Upgraded requirements.txt to the latest stable versions of Flask, Paho-MQTT (2.1.0), and Eventlet for better security and performance.

**Code Refactoring:**
 - Updated MQTT client initialization to use CallbackAPIVersion.VERSION2 to maintain compatibility with the latest Paho-MQTT library.

**Why this is needed:**
Previously, the UI could only connect to unencrypted brokers. This update allows users to connect to secure enterprise or public brokers requiring SSL/TLS, making the tool much more versatile for production environments.